### PR TITLE
The first working version

### DIFF
--- a/src/lambdas/breeds-get.test.ts
+++ b/src/lambdas/breeds-get.test.ts
@@ -1,0 +1,48 @@
+import fetch from 'node-fetch'
+import { handler } from './breeds-get'
+
+const mockedFetch: jest.Mock = fetch as any
+
+jest.mock('node-fetch')
+
+describe('breeds-get handler', () => {
+  const mockPayload = {
+    message: {
+      beagle: [],
+      sheepdog: ['english', 'shetland'],
+    },
+    status: 'success',
+  }
+
+  const mockExpectedBody = {
+    message: ['beagle', 'english sheepdog', 'shetland sheepdog'],
+    status: 'success',
+  }
+
+  beforeEach(() => {
+    mockedFetch.mockResolvedValueOnce({
+      status: 200,
+      statusText: 'OK',
+      ok: true,
+      json: () => {
+        return mockPayload
+      },
+    })
+
+    mockedFetch.mockResolvedValueOnce({
+      status: 408,
+      statusText: 'Request Timeout',
+      ok: false,
+      json: {},
+    })
+  })
+
+  it('returns payload from fetch request', async () => {
+    const response = await handler()
+    expect(response).toMatchObject({ body: mockExpectedBody })
+  })
+
+  it('the fetch fails with timeout error', async () => {
+    await expect(handler()).rejects.toThrow('HTTP Error Response')
+  })
+})

--- a/src/lambdas/breeds-get.ts
+++ b/src/lambdas/breeds-get.ts
@@ -1,0 +1,45 @@
+import fetch from 'node-fetch'
+import { Response } from './types'
+
+interface BreedsResponse extends Response {
+  body: Breeds
+}
+
+interface Breeds {
+  message: string[]
+  status: string
+}
+
+function parseBreeds(message: object): string[] {
+  const breeds: string[] = []
+
+  Object.entries(message).forEach(element => {
+    const key = element[0]
+    const value = element[1]
+
+    if (value.length === 0) {
+      breeds.push(`${key}`)
+    } else {
+      value.forEach((sub: string) => {
+        breeds.push(`${sub} ${key}`)
+      })
+    }
+  })
+
+  return breeds
+}
+
+export async function handler(): Promise<BreedsResponse> {
+  const res = await fetch('https://dog.ceo/api/breeds/list/all')
+  if (!res.ok) {
+    throw new Error(`HTTP Error Response: ${res.status} ${res.statusText}`)
+  }
+
+  const json = await res.json()
+  const breedsMessage: string[] = await parseBreeds(json.message)
+  const payload: Breeds = { message: breedsMessage, status: json.status as string }
+  return {
+    statusCode: 200,
+    body: payload,
+  }
+}


### PR DESCRIPTION
This branch is created to fetching dog breeds from the dog-list endpoint. Changes in this commit:

-  added `breed-get.ts`: fetching the dog-list endpoint and parsing from the response to create a dog breed string array. HTTP errors are handled by the `throw` statement

- added `breed-get.test.ts`: created tests to test the following situations: 1. the happy path 2. the external call timing out. Since the results of the API call are mocked, no Internet connections are required during the tests.

All the code has passed the `lint` and `build` without warnings or errors. 

Questions: 
Does the `external call timing out` mentioned in the requirement mean the `HTTP 408 Request Timeout` error?